### PR TITLE
chore(docs): update README year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Hacktoberfest 2025 banner](./pykitzoid_hacktoberfest.png)
 
-# Hacktoberfest 2023 with IEEE-VIT :blue_heart:
+# Hacktoberfest 2025 with IEEE-VIT :blue_heart:
 
 This is a repository containing a Python package coded in Go, with the motive of providing ML support.
 


### PR DESCRIPTION
Updates the README’s year from 2023 → 2025 to keep documentation current.
Scope: README only; no code changes or build impact.


<img width="1333" height="668" alt="Screenshot 2025-10-19 035124" src="https://github.com/user-attachments/assets/5c1489d5-2110-4ea9-b3d9-d5252c67bff7" />


<img width="1277" height="757" alt="image" src="https://github.com/user-attachments/assets/4f8cb99f-7e12-46ee-bd64-60313e8d393e" />
